### PR TITLE
Split env vars from tenant config

### DIFF
--- a/app.server/config/config.eocoe.ts
+++ b/app.server/config/config.eocoe.ts
@@ -1,4 +1,3 @@
-import * as dotenv from 'dotenv'
 import { ServerConfig } from './ServerConfig'
 
 export const config: ServerConfig = {
@@ -8,28 +7,5 @@ export const config: ServerConfig = {
   collectionSearchOGCPattern: '',
   collectionSearchPattern: 'eo/*',
   productSearchEndpoint: 'search/product',
-  productOGC: true
+  productOGC: false,
 }
-
-function getIntFromEnvVariable(env: string | undefined, defaultValue: number) : number {
-  try {
-    if (env !== undefined) {
-      return Number.parseInt(env)
-    }
-  } finally {
-    return defaultValue
-  }
-}
-
-dotenv.config()
-
-export const POSTGRES_HOST = process.env.POSTGRES_HOST
-export const POSTGRES_PORT = getIntFromEnvVariable(process.env.POSTGRES_PORT, 5432)
-export const POSTGRES_USER = process.env.POSTGRES_USER
-export const POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD
-export const POSTGRES_DATABASE = process.env.POSTGRES_DATABASE
-export const POSTGRES_SSL = process.env.POSTGRES_SSL === 'true' ? true : false
-
-export const CATALOG_API_URL = `${process.env.CATALOG_API_PROTOCOL}://${process.env.CATALOG_API_HOST}`
-
-export const GEOSERVER_URL = `${process.env.GEOSERVER_PROTOCOL}://${process.env.GEOSERVER_HOST}`

--- a/app.server/config/config.lidar.ts
+++ b/app.server/config/config.lidar.ts
@@ -1,4 +1,3 @@
-import * as dotenv from 'dotenv'
 import { ServerConfig } from './ServerConfig'
 
 export const config: ServerConfig = {
@@ -8,28 +7,5 @@ export const config: ServerConfig = {
   collectionSearchOGCPattern: 'scotland-gov/lidar/ogc',
   collectionSearchPattern: 'scotland-gov/lidar/phase*',
   productSearchEndpoint: 'search/product',
-  productOGC: false
+  productOGC: false,
 }
-
-function getIntFromEnvVariable(env: string | undefined, defaultValue: number) : number {
-  try {
-    if (env !== undefined) {
-      return Number.parseInt(env)
-    }
-  } finally {
-    return defaultValue
-  }
-}
-
-dotenv.config()
-
-export const POSTGRES_HOST = process.env.POSTGRES_HOST
-export const POSTGRES_PORT = getIntFromEnvVariable(process.env.POSTGRES_PORT, 5432)
-export const POSTGRES_USER = process.env.POSTGRES_USER
-export const POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD
-export const POSTGRES_DATABASE = process.env.POSTGRES_DATABASE
-export const POSTGRES_SSL = process.env.POSTGRES_SSL === 'true' ? true : false
-
-export const CATALOG_API_URL = `${process.env.CATALOG_API_PROTOCOL}://${process.env.CATALOG_API_HOST}`
-
-export const GEOSERVER_URL = `${process.env.GEOSERVER_PROTOCOL}://${process.env.GEOSERVER_HOST}`

--- a/app.server/config/config.ts
+++ b/app.server/config/config.ts
@@ -1,32 +1,8 @@
 /** This file gets overwritten in a production build with one of the
  *  tenant-specific config files in this directory */
-import * as dotenv from 'dotenv'
 import { ServerConfig } from './ServerConfig'
 
 // feel free to change the below import to switch between tenant configs at dev time
 import { config as c}  from './config.lidar'
 
 export const config: ServerConfig = c
-
-function getIntFromEnvVariable(env: string | undefined, defaultValue: number) : number {
-  try {
-    if (env !== undefined) {
-      return Number.parseInt(env)
-    }
-  } finally {
-    return defaultValue
-  }
-}
-
-dotenv.config()
-
-export const POSTGRES_HOST = process.env.POSTGRES_HOST
-export const POSTGRES_PORT = getIntFromEnvVariable(process.env.POSTGRES_PORT, 5432)
-export const POSTGRES_USER = process.env.POSTGRES_USER
-export const POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD
-export const POSTGRES_DATABASE = process.env.POSTGRES_DATABASE
-export const POSTGRES_SSL = process.env.POSTGRES_SSL === 'true' ? true : false
-
-export const CATALOG_API_URL = `${process.env.CATALOG_API_PROTOCOL}://${process.env.CATALOG_API_HOST}`
-
-export const GEOSERVER_URL = `${process.env.GEOSERVER_PROTOCOL}://${process.env.GEOSERVER_HOST}`

--- a/app.server/data/catalog/catalog.ts
+++ b/app.server/data/catalog/catalog.ts
@@ -1,4 +1,5 @@
-import * as config from '../../config/config';
+import { env } from '../../env';
+import { config } from '../../config/config';
 import { GetCollectionsResult, WMSData } from '../../handlers/collections/models';
 import { Query } from '../../../app.client/components/models/Query';
 import { GetProductsResult } from '../../handlers/products/models';
@@ -23,7 +24,7 @@ export class Catalog {
   async getOGCServiceList(): Promise<{ [id: string]: WMSData }> {
     let entireWorldBbox = [-180.0, -85.06, 180.0, 85.06]
     let layers = await this.getProducts({
-      collections: [config.config.collectionSearchOGCPattern],
+      collections: [config.collectionSearchOGCPattern],
       offset: 0,
       limit: 50,
       bbox: entireWorldBbox,
@@ -47,8 +48,8 @@ export class Catalog {
     return this.geoserverLayers[collection];
   }
 
-  public async getCollections(pattern: string = config.config.collectionSearchPattern): Promise<GetCollectionsResult> {
-    return axios.get(urljoin(config.CATALOG_API_URL, config.config.collectionSearchEndpoint, pattern)).then((response) => {
+  public async getCollections(pattern: string = config.collectionSearchPattern): Promise<GetCollectionsResult> {
+    return axios.get(urljoin(env.CATALOG_API_URL, config.collectionSearchEndpoint, pattern)).then((response) => {
       return {
         collections: (response.data.result).map((collection: any) => {
           return {
@@ -74,7 +75,7 @@ export class Catalog {
   }
 
   public async getProducts(query: Query): Promise<GetProductsResult> {
-    return axios.post(urljoin(config.CATALOG_API_URL, config.config.productSearchEndpoint), {
+    return axios.post(urljoin(env.CATALOG_API_URL, config.productSearchEndpoint), {
       collection: query.collections[0],
       footprint: this.generateWKTFromBBOX(query.bbox),
       spatialOp: 'overlaps',
@@ -87,7 +88,7 @@ export class Catalog {
           metadata: { title: '', abstract: '', useConstraints: '' },
           metadataExternalLink: '',
           // If we are fetching the ogc layer don't set the wms for this collection
-          data: query.collections[0] === config.config.collectionSearchOGCPattern ? {} : {
+          data: query.collections[0] === config.collectionSearchOGCPattern ? {} : {
             wms: this.getOGCServiceForCollection(query.collections[0])
           },
           products: (response.data.result).map((product: any) => {

--- a/app.server/data/database.ts
+++ b/app.server/data/database.ts
@@ -1,7 +1,7 @@
 
 import * as pgPromise from 'pg-promise'
 import { IMain, IDatabase } from 'pg-promise'
-import  * as config from '../config/config';
+import { env } from '../env'
 
 /* Singleton database client. */
 export class Database {
@@ -12,12 +12,12 @@ export class Database {
     constructor() {
         let pgp = pgPromise()
         let cn = {
-          host: config.POSTGRES_HOST,
-          port: config.POSTGRES_PORT,
-          database: config.POSTGRES_DATABASE,
-          username: config.POSTGRES_USER,
-          password: config.POSTGRES_PASSWORD,
-          ssl: config.POSTGRES_SSL
+          host: env.POSTGRES_HOST,
+          port: env.POSTGRES_PORT,
+          database: env.POSTGRES_DATABASE,
+          username: env.POSTGRES_USER,
+          password: env.POSTGRES_PASSWORD,
+          ssl: env.POSTGRES_SSL
         }
         this.connection = pgp(cn)
     }

--- a/app.server/env.ts
+++ b/app.server/env.ts
@@ -1,3 +1,7 @@
+import * as dotenv from 'dotenv'
+
+// Need to do this here otherwise the const will return undefined
+dotenv.config()
 
 export const env = {
   POSTGRES_HOST: process.env.POSTGRES_HOST || '',

--- a/app.server/env.ts
+++ b/app.server/env.ts
@@ -1,0 +1,21 @@
+
+export const env = {
+  POSTGRES_HOST: process.env.POSTGRES_HOST || '',
+  POSTGRES_PORT: getIntFromEnvVariable(process.env.POSTGRES_PORT, 5432),
+  POSTGRES_USER: process.env.POSTGRES_USER || '',
+  POSTGRES_PASSWORD: process.env.POSTGRES_PASSWORD || '',
+  POSTGRES_DATABASE: process.env.POSTGRES_DATABASE || '',
+  POSTGRES_SSL: process.env.POSTGRES_SSL === 'true' ? true : false,
+  CATALOG_API_URL: `${process.env.CATALOG_API_PROTOCOL}://${process.env.CATALOG_API_HOST}`,
+  GEOSERVER_URL: `${process.env.GEOSERVER_PROTOCOL}://${process.env.GEOSERVER_HOST}`
+}
+
+function getIntFromEnvVariable(env: string | undefined, defaultValue: number) : number {
+  try {
+    if (env !== undefined) {
+      return Number.parseInt(env)
+    }
+  } finally {
+    return defaultValue
+  }
+}

--- a/app.server/handlers/wms/getCapabilities.ts
+++ b/app.server/handlers/wms/getCapabilities.ts
@@ -1,7 +1,7 @@
 
 import { Product } from './../products/models'
 import { template } from './template'
-import * as config from '../../config/config'
+import { env } from '../../env'
 
 export function getCapabilities(products: Product[], wmsUrl: string): String {
 
@@ -15,7 +15,7 @@ export function getCapabilities(products: Product[], wmsUrl: string): String {
   // (split + join is javascript for 'String.replaceAll'!)
   return template
     .replace('{{{products}}}', productsXml)
-    .split(config.GEOSERVER_URL).join(wmsUrl)
+    .split(env.GEOSERVER_URL).join(wmsUrl)
 }
 
 export function makeLayerXml(p: Product): string {

--- a/app.server/server.ts
+++ b/app.server/server.ts
@@ -2,6 +2,7 @@
 import * as express from 'express'
 import * as bodyParser from 'body-parser'
 import * as _ from 'lodash'
+import * as dotenv from 'dotenv'
 
 import { pages } from './routes'
 import { getEnvironmentSettings, getRealWmsUrl } from './settings'
@@ -13,6 +14,8 @@ import { parseQuerystring } from './query/parseQuerystring'
 import { StoredQueryRepository, FakeStoredQueryRepository } from './data/storedQueryRepository'
 import { Catalog } from './data/catalog/catalog'
 import { GetCollectionsResult } from './handlers/collections/models'
+
+dotenv.config()
 
 let app = express()
 let env = getEnvironmentSettings(app.settings.env)

--- a/app.server/server.ts
+++ b/app.server/server.ts
@@ -2,7 +2,6 @@
 import * as express from 'express'
 import * as bodyParser from 'body-parser'
 import * as _ from 'lodash'
-import * as dotenv from 'dotenv'
 
 import { pages } from './routes'
 import { getEnvironmentSettings, getRealWmsUrl } from './settings'
@@ -14,8 +13,6 @@ import { parseQuerystring } from './query/parseQuerystring'
 import { StoredQueryRepository, FakeStoredQueryRepository } from './data/storedQueryRepository'
 import { Catalog } from './data/catalog/catalog'
 import { GetCollectionsResult } from './handlers/collections/models'
-
-dotenv.config()
 
 let app = express()
 let env = getEnvironmentSettings(app.settings.env)

--- a/app.server/settings.ts
+++ b/app.server/settings.ts
@@ -1,4 +1,6 @@
-import * as config from './config/config'
+import { env } from './env'
+
+// these dyanmic environment values could be possibiliy be combined with the newer `env.ts`
 
 export function getEnvironmentSettings(env: string) {
   if (env === 'development') {
@@ -20,5 +22,5 @@ export function getEnvironmentSettings(env: string) {
 }
 
 export function getRealWmsUrl() {
-  return config.GEOSERVER_URL
+  return env.GEOSERVER_URL
 }


### PR DESCRIPTION
Splits the existing statically-defined tenant configuration from the recently introduced environment variables. 

- new `env.ts` env variable file
- remove double `config.config.` access by using import a single export
- remove triple duplication of tenant / config files to restore simplicity

I've stacked this on top of PR #48 since we already have another PR merged into that one now. 

I haven't been able to test this as I currently can't run locally @felixMasonJncc could you have a go?